### PR TITLE
THRST-344 Minimise Partial Upload Errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
       
       - name: Deployment of breaking change to Azure File Share successful
         run: |
-          sleep 5
+          sleep 30
           receivedIndexHtml=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat INDEX_HTML_FILE)")
           receivedMainJs=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat MAIN_JS_FILE)")
           receivedPolyfillsJs=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat POLYFILLS_JS_FILE)")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,6 @@ jobs:
       
       - name: Deployment of breaking change to Azure File Share successful
         run: |
-          sleep 30
           receivedIndexHtml=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat INDEX_HTML_FILE)")
           receivedMainJs=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat MAIN_JS_FILE)")
           receivedPolyfillsJs=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat POLYFILLS_JS_FILE)")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,13 @@ jobs:
           receivedLogoutHtml=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat LOGOUT_HTML_FILE)")
           if [[ $receivedIndexHtml != $(cat EXPECTED_BROKEN_INDEX_HTML) || $receivedMainJs != $(cat EXPECTED_BROKEN_MAIN_JS) || $receivedPolyfillsJs != $(cat EXPECTED_BROKEN_POLYFILLS_JS) || $receivedPolyfillsEs5Js != $(cat EXPECTED_BROKEN_POLYFILLS_ES5_JS) || $receivedStylesCss != $(cat EXPECTED_BROKEN_STYLES_CSS) || $receivedScriptsJs != $(cat EXPECTED_BROKEN_SCRIPTS_JS) || $receivedLogoutHtml != $(cat EXPECTED_BROKEN_LOGOUT_HTML) ]] ; then
             echo "::error ::Deployment has not been successful"
+            echo "Received index.html: $receivedIndexHtml"
+            echo "Received main.js $receivedMainJs"
+            echo "Received polyfills.js $receivedPolyfillsJs"
+            echo "Received polyfills-es5.js $receivedPolyfillsEs5Js"
+            echo "Received styles.css $receivedStylesCss"
+            echo "Received scripts.js $receivedScriptsJs"
+            echo "Received logout.html $receivedLogoutHtml"
             exit 1
           fi
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,7 @@ jobs:
       
       - name: Deployment of breaking change to Azure File Share successful
         run: |
+          sleep 5
           receivedIndexHtml=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat INDEX_HTML_FILE)")
           receivedMainJs=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat MAIN_JS_FILE)")
           receivedPolyfillsJs=$(curl -X GET -H "x-ms-date: $(date -u)" "$(cat POLYFILLS_JS_FILE)")

--- a/dist/index.js
+++ b/dist/index.js
@@ -11357,28 +11357,21 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     // not yet uploaded artifacts.
     // It then might take up to two minutes before the app is usable again.
     const rootFilesPattern = Array.from(filesToVersion).join(';');
+    // Upload all files to nextRelease/ directory
     await exec.exec('./azcopy', [
         'copy', sourceDirectory + '/*',
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
-        '--exclude-path', rootFilesPattern,
         '--recursive'
     ]);
+    // Copy all files from the nextRelease/ directory into the root directory
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
         '--recursive'
     ]);
-    // Sync uncached root files to the File storage
-    // because now all other files have been uploaded
-    await exec.exec('./azcopy', [
-        'copy', sourceDirectory + '/*',
-        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
-        '--include-path', rootFilesPattern,
-        '--recursive'
-    ]);
     // Delete nextRelease/ directory
     await exec.exec('./azcopy', [
-        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
+        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
         '--recursive'
     ]);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -11367,7 +11367,7 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     // Copy all files from the nextRelease/ directory into the root directory
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
-        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}`,
         '--recursive'
     ]);
     // Delete nextRelease/ directory

--- a/dist/index.js
+++ b/dist/index.js
@@ -11376,6 +11376,11 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
         '--include-path', rootFilesPattern,
         '--recursive'
     ]);
+    // Delete nextRelease/ directory
+    await exec.exec('./azcopy', [
+        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
+        '--recursive'
+    ]);
 }
 
 async function versionBranchOfApp(appName) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11361,12 +11361,14 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     await exec.exec('./azcopy', [
         'copy', sourceDirectory + '/*',
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
+        '--overwrite', 'true',
         '--recursive'
     ]);
     // Copy all files from the nextRelease/ directory into the root directory
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        '--overwrite', 'true',
         '--recursive'
     ]);
     // Delete nextRelease/ directory

--- a/dist/index.js
+++ b/dist/index.js
@@ -11378,7 +11378,7 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     ]);
     // Delete nextRelease/ directory
     await exec.exec('./azcopy', [
-        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
+        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         '--recursive'
     ]);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -11359,10 +11359,15 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     const rootFilesPattern = Array.from(filesToVersion).join(';');
     await exec.exec('./azcopy', [
         'copy', sourceDirectory + '/*',
-        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
         '--exclude-path', rootFilesPattern,
         '--recursive'
-    ])
+    ]);
+    await exec.exec('./azcopy', [
+        'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
+        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        '--recursive'
+    ]);
     // Sync uncached root files to the File storage
     // because now all other files have been uploaded
     await exec.exec('./azcopy', [

--- a/dist/index.js
+++ b/dist/index.js
@@ -11368,7 +11368,6 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
-        '--overwrite', 'true',
         '--recursive'
     ]);
     // Delete nextRelease/ directory

--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     ]);
     // Delete nextRelease/ directory
     await exec.exec('./azcopy', [
-        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
+        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         '--recursive'
     ]);
 }

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     // Copy all files from the nextRelease/ directory into the root directory
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
-        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}`,
         '--recursive'
     ]);
     // Delete nextRelease/ directory

--- a/index.js
+++ b/index.js
@@ -188,28 +188,21 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     // not yet uploaded artifacts.
     // It then might take up to two minutes before the app is usable again.
     const rootFilesPattern = Array.from(filesToVersion).join(';');
+    // Upload all files to nextRelease/ directory
     await exec.exec('./azcopy', [
         'copy', sourceDirectory + '/*',
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
-        '--exclude-path', rootFilesPattern,
         '--recursive'
     ]);
+    // Copy all files from the nextRelease/ directory into the root directory
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
         '--recursive'
     ]);
-    // Sync uncached root files to the File storage
-    // because now all other files have been uploaded
-    await exec.exec('./azcopy', [
-        'copy', sourceDirectory + '/*',
-        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
-        '--include-path', rootFilesPattern,
-        '--recursive'
-    ]);
     // Delete nextRelease/ directory
     await exec.exec('./azcopy', [
-        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
+        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
         '--recursive'
     ]);
 }

--- a/index.js
+++ b/index.js
@@ -199,7 +199,6 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
-        '--overwrite', 'true',
         '--recursive'
     ]);
     // Delete nextRelease/ directory

--- a/index.js
+++ b/index.js
@@ -190,10 +190,15 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     const rootFilesPattern = Array.from(filesToVersion).join(';');
     await exec.exec('./azcopy', [
         'copy', sourceDirectory + '/*',
-        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
         '--exclude-path', rootFilesPattern,
         '--recursive'
-    ])
+    ]);
+    await exec.exec('./azcopy', [
+        'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
+        `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        '--recursive'
+    ]);
     // Sync uncached root files to the File storage
     // because now all other files have been uploaded
     await exec.exec('./azcopy', [

--- a/index.js
+++ b/index.js
@@ -192,12 +192,14 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
     await exec.exec('./azcopy', [
         'copy', sourceDirectory + '/*',
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
+        '--overwrite', 'true',
         '--recursive'
     ]);
     // Copy all files from the nextRelease/ directory into the root directory
     await exec.exec('./azcopy', [
         'copy', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease/*?${sasToken}`,
         `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}?${sasToken}`,
+        '--overwrite', 'true',
         '--recursive'
     ]);
     // Delete nextRelease/ directory

--- a/index.js
+++ b/index.js
@@ -207,6 +207,11 @@ async function deployToContainerOfStorageAccount(sourceDirectory, storageAccount
         '--include-path', rootFilesPattern,
         '--recursive'
     ]);
+    // Delete nextRelease/ directory
+    await exec.exec('./azcopy', [
+        'rm', `https://${storageAccount}.file.core.windows.net/k8s-cdn-proxy/${container}/nextRelease?${sasToken}`,
+        '--recursive'
+    ]);
 }
 
 async function versionBranchOfApp(appName) {


### PR DESCRIPTION
- Minimise chunk load errors by first uploading the release in an extra folder and then moving the files into the root directory as a second step

⚠️ Chunk errors are often caused by customers accessing partially uploaded files (for example fingerprinted files that are not changed or files without fingerprints).